### PR TITLE
fix(WEB-8622): Add `index_pages` to `only` to enable/disable pagination in blog index

### DIFF
--- a/lib/literature/router.ex
+++ b/lib/literature/router.ex
@@ -149,7 +149,7 @@ defmodule Literature.Router do
   defmacro literature(path, opts \\ []) do
     opts = Keyword.put(opts, :application_router, __CALLER__.module)
 
-    routes = Keyword.get(opts, :only, ~w(index tags authors show)a)
+    routes = Keyword.get(opts, :only, ~w(index index_pages tags authors show)a)
 
     session_name = Keyword.get(opts, :as, :literature)
 
@@ -182,6 +182,9 @@ defmodule Literature.Router do
               # Blog routes
               if :index in routes do
                 live("/", BlogLive, :index, route_opts)
+              end
+
+              if :index_pages in routes do
                 live("/page/:page", BlogLive, :index, route_opts)
               end
 


### PR DESCRIPTION
### Changes
 - Add index_pages to routes to enable disable /page/:page routes