### PR TITLE
feat(WEB-8889): Allow create routes on root

### DIFF
--- a/lib/literature/controllers/rss_controller.ex
+++ b/lib/literature/controllers/rss_controller.ex
@@ -10,7 +10,7 @@ defmodule Literature.RSSController do
   def rss(conn, _params) do
     base_path = String.replace(current_path(conn), @default_path, "")
     base_url = Config.feed_url() <> base_path
-    publication_slug = String.split(base_path, "/") |> List.last()
+    publication_slug = conn.private[:publication_slug]
     publication = Literature.get_publication!(slug: publication_slug)
 
     conn

--- a/test/literature/plugs/redirect_test.exs
+++ b/test/literature/plugs/redirect_test.exs
@@ -20,10 +20,13 @@ defmodule Literature.Plugs.RedirectTest do
       conn =
         Plug.Test.conn(:get, req_path, %{})
         |> put_private(:publication_slug, publication.slug)
+        |> put_private(:root_path, "/blog")
         |> Redirect.call([])
 
       assert conn.halted
-      assert redirected_to(conn, redirect.type) == "/#{publication.slug}#{redirect.to}"
+
+      assert redirected_to(conn, redirect.type) ==
+               "#{conn.private.root_path}#{redirect.to}"
     end
 
     test "redirects authors to tags with dynamic path", %{
@@ -39,6 +42,7 @@ defmodule Literature.Plugs.RedirectTest do
       conn =
         Plug.Test.conn(:get, req_path, %{})
         |> put_private(:publication_slug, publication.slug)
+        |> put_private(:root_path, "/foo/bar/blog")
         |> Redirect.call([])
 
       assert conn.halted

--- a/test/literature/router_test.exs
+++ b/test/literature/router_test.exs
@@ -3,6 +3,7 @@ defmodule Literature.RouterTest do
 
   import Literature.Test.Fixtures
 
+  alias Literature.Test.DynamicPathRouter
   alias Literature.Test.DynamicPathRouter.Helpers, as: DynamicPathRoutes
   alias Literature.Test.Router
 
@@ -54,23 +55,50 @@ defmodule Literature.RouterTest do
 
       assert Routes.literature_path(conn, :rss) == "/blog/rss.xml"
     end
+  end
 
-    test "generates helper only for specified routes", %{conn: conn} do
-      paths =
-        Router.__routes__()
-        |> Enum.filter(&(&1.helper == "with_only"))
-        |> Enum.map(& &1.path)
+  test "generates helper only for specified routes", %{conn: conn} do
+    paths =
+      Router.__routes__()
+      |> Enum.filter(&(&1.helper == "with_only"))
+      |> Enum.map(& &1.path)
 
-      assert Enum.sort(paths) ==
-               Enum.sort(["/with-only", "/with-only/:slug", "/with-only/rss.xml"])
+    assert Enum.sort(paths) ==
+             Enum.sort(["/with-only", "/with-only/:slug", "/with-only/rss.xml"])
 
-      assert Routes.with_only_path(conn, :index) == "/with-only"
+    assert Routes.with_only_path(conn, :index) == "/with-only"
 
-      assert Routes.with_only_path(conn, :show, "author-or-tag-or-post") ==
-               "/with-only/author-or-tag-or-post"
+    assert Routes.with_only_path(conn, :show, "author-or-tag-or-post") ==
+             "/with-only/author-or-tag-or-post"
 
-      assert Routes.with_only_path(conn, :rss) == "/with-only/rss.xml"
-    end
+    assert Routes.with_only_path(conn, :rss) == "/with-only/rss.xml"
+  end
+
+  test "generates helpers on root", %{conn: conn} do
+    paths =
+      Router.__routes__()
+      |> Enum.filter(&(&1.helper == "on_root"))
+      |> Enum.map(& &1.path)
+
+    assert Enum.sort(paths) ==
+             Enum.sort([
+               "/",
+               "/:slug",
+               "/authors",
+               "/tags",
+               "/page/:page",
+               "/rss.xml"
+             ])
+
+    assert Routes.on_root_path(conn, :index) == "/"
+    assert Routes.on_root_path(conn, :index, 2) == "/page/2"
+    assert Routes.on_root_path(conn, :authors) == "/authors"
+    assert Routes.on_root_path(conn, :tags) == "/tags"
+
+    assert Routes.on_root_path(conn, :show, "author_or_tag_or_post") ==
+             "/author_or_tag_or_post"
+
+    assert Routes.on_root_path(conn, :rss) == "/rss.xml"
   end
 
   describe "literature_path/2 for dynamic path" do
@@ -85,6 +113,33 @@ defmodule Literature.RouterTest do
 
       assert DynamicPathRoutes.literature_path(conn, :rss) == "/foo/bar/blog/rss.xml"
     end
+  end
+
+  test "generates helpers on root with dynamic path", %{conn: conn} do
+    paths =
+      DynamicPathRouter.__routes__()
+      |> Enum.filter(&(&1.helper == "on_root"))
+      |> Enum.map(& &1.path)
+
+    assert Enum.sort(paths) ==
+             Enum.sort([
+               "/dynamic-on-root",
+               "/dynamic-on-root/:slug",
+               "/dynamic-on-root/authors",
+               "/dynamic-on-root/tags",
+               "/dynamic-on-root/page/:page",
+               "/dynamic-on-root/rss.xml"
+             ])
+
+    assert DynamicPathRoutes.on_root_path(conn, :index) == "/dynamic-on-root"
+    assert DynamicPathRoutes.on_root_path(conn, :index, 2) == "/dynamic-on-root/page/2"
+    assert DynamicPathRoutes.on_root_path(conn, :authors) == "/dynamic-on-root/authors"
+    assert DynamicPathRoutes.on_root_path(conn, :tags) == "/dynamic-on-root/tags"
+
+    assert DynamicPathRoutes.on_root_path(conn, :show, "author_or_tag_or_post") ==
+             "/dynamic-on-root/author_or_tag_or_post"
+
+    assert DynamicPathRoutes.on_root_path(conn, :rss) == "/dynamic-on-root/rss.xml"
   end
 
   describe "literature_api_path/2 for default path" do

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -7,7 +7,7 @@ defmodule Literature.Test.Router do
   literature_assets("/blog")
 
   literature("/",
-    publication_slug: "blog",
+    publication: "blog",
     view_module: @view_module
   )
 
@@ -15,17 +15,24 @@ defmodule Literature.Test.Router do
   literature_dashboard("/literature")
 
   literature("/",
-    publication_slug: "error-view",
+    publication: "error-view",
     view_module: @view_module,
     error_view_module: Literature.Test.ErrorView,
     as: :error_view
   )
 
   literature("/",
-    publication_slug: "with-only",
+    publication: "with-only",
     only: [:index, :show],
     view_module: @view_module,
     as: :with_only
+  )
+
+  literature("/",
+    publication: "on-root",
+    view_module: @view_module,
+    as: :on_root,
+    root: true
   )
 end
 
@@ -36,9 +43,16 @@ defmodule Literature.Test.DynamicPathRouter do
   @view_module Literature.BlogView
 
   literature_assets("/foo/bar")
-  literature("/foo/bar", publication_slug: "blog", view_module: @view_module)
+  literature("/foo/bar", publication: "blog", view_module: @view_module)
   literature_api("/foo/bar")
   literature_dashboard("/foo/bar")
+
+  literature("/dynamic-on-root",
+    publication: "on-root",
+    view_module: @view_module,
+    as: :on_root,
+    root: true
+  )
 end
 
 defmodule Literature.Test.ErrorView do


### PR DESCRIPTION
### Changes
1. Add `root` opt on `literature/2` to allow creating routes on root without the `publication_slug` on scope
2. rename `publication_slug` opt to `publication`