### PR TITLE
feat(WEB-7437): [MB][Literature] Use a thumb for author image

### DIFF
--- a/lib/literature/author.ex
+++ b/lib/literature/author.ex
@@ -7,7 +7,7 @@ defmodule Literature.Author do
   schema "literature_authors" do
     field(:slug, :string)
     field(:name, :string)
-    field(:profile_image, Uploaders.Type)
+    field(:profile_image, Uploaders.ProfileImage.Type)
     field(:cover_image, Uploaders.Type)
     field(:bio, :string)
     field(:website, :string)

--- a/lib/literature/uploaders/profile_image.ex
+++ b/lib/literature/uploaders/profile_image.ex
@@ -1,0 +1,62 @@
+defmodule Literature.Uploaders.ProfileImage do
+  @moduledoc """
+  Literature Profile Image Uploader
+  """
+  use Waffle.Definition
+  use Waffle.Ecto.Definition
+
+  alias Literature.Config
+  alias Literature.Uploaders.Helpers
+
+  @extension_whitelist ~w(.jpg .jpeg .png)
+  # imagemagick 7 is required for avif conversions
+  @versions ~w(jpg png webp)a
+
+  def asset_host, do: Config.waffle_asset_host()
+  def bucket, do: Config.waffle_bucket()
+  def __storage, do: Config.waffle_storage()
+
+  # Whitelist file extensions:
+  def validate({file, _}) do
+    Enum.member?(
+      @extension_whitelist,
+      file.file_name
+      |> Path.extname()
+      |> String.downcase()
+    )
+  end
+
+  def transform(:jpg, _) do
+    {:convert, "-resize 160x -format jpg", :jpg}
+  end
+
+  def transform(:png, _) do
+    {:convert, "-resize 160x -format png", :png}
+  end
+
+  def transform(:webp, _) do
+    {:convert, "-resize 160x -format webp", :webp}
+  end
+
+  def storage_dir(_, {_, scope}),
+    do: "literature/#{scope.id}"
+
+  # Original filename has width and height so we append just the width to the filename,
+  # otherwise, no changes to the filename will be made
+  def filename(_version, {%{file_name: file_name_with_ext}, _}) do
+    base_file_name = Path.basename(file_name_with_ext, Path.extname(file_name_with_ext))
+
+    case Helpers.get_dimension(file_name_with_ext) do
+      {width, _height} ->
+        suffix = String.split(base_file_name, "w") |> List.last()
+        Slugy.slugify(String.replace_suffix(base_file_name, suffix, to_string(width)))
+
+      _ ->
+        Slugy.slugify(base_file_name)
+    end
+  end
+
+  def s3_object_headers(_version, _) do
+    [cache_control: "public, max-age=31536000"]
+  end
+end


### PR DESCRIPTION
This is done by adding another input as an indirection to the live_file_input to prevent immediate upload. A resize hook is then attached to the new input which will resize the incoming image before passing to the live_file_input.

To test: (Based on #248)

Note that all tests below should be done with the master branch of https://github.com/martide/elixir

1. Since this change hasn't been released yet. In the elixir repository code, replace all written {:literature, "~> 0.1"}, with {:literature, git: "https://github.com/martide/literature.git", branch: "resize"}, Use find and replace in your code editor
2. Run mix deps.get in your terminal
3. Run the server mix phx.server
4. https://localhost:4103/literature/blog/posts
5. Go to https://localhost:4103/literature/blog/authors add or edit an author
6. In the profile image, upload a file with width > 160. (Note that if the filename already exists when editing, you may need to rename it so that waffle will replace it with the resized one).
7. Go to https://localhost:4203/en/blog/authors
8. Inspect the author image, the src attribute should have an image with a width of 160.