### PR TITLE
Add feature for searching posts under a publication

### DIFF
--- a/lib/literature/live/blog_live.ex
+++ b/lib/literature/live/blog_live.ex
@@ -171,7 +171,7 @@ defmodule Literature.BlogLive do
     |> then(&{:noreply, &1})
   end
 
-  defp apply_action(socket, :index, slug, params) do
+  defp apply_action(socket, action, slug, params) when action in [:index, :search] do
     publication = Literature.get_publication!(slug: slug)
     page = paginate_posts(socket, params)
 
@@ -181,6 +181,7 @@ defmodule Literature.BlogLive do
     |> assign(:publication, publication)
     |> assign(:page, page)
     |> assign(:posts, page.entries)
+    |> assign(:search_term, params["q"])
     |> handle_page_exceeds_total(params, page.total_pages)
   end
 
@@ -241,7 +242,8 @@ defmodule Literature.BlogLive do
       "status" => "published",
       "preload" => ~w(authors tags)a,
       "page" => params["page"],
-      "page_size" => @page_size
+      "page_size" => @page_size,
+      "q" => params["q"]
     }
     |> Literature.paginate_posts()
   end

--- a/lib/literature/router.ex
+++ b/lib/literature/router.ex
@@ -152,7 +152,7 @@ defmodule Literature.Router do
     opts = Keyword.put(opts, :application_router, __CALLER__.module)
 
     # :index_pages to enable index pagination
-    routes = Keyword.get(opts, :only, ~w(index index_pages tags authors show)a)
+    routes = Keyword.get(opts, :only, ~w(index index_pages tags authors search show)a)
 
     # Custom routes to enable /tags/:tag_slug or /authors/:author_slug routes
     # Possible value for now is [:show_tag, :show_author]

--- a/lib/literature/router.ex
+++ b/lib/literature/router.ex
@@ -215,6 +215,11 @@ defmodule Literature.Router do
                 live("/authors", BlogLive, :authors, route_opts)
               end
 
+              if :search in routes do
+                live("/search/page/:page", BlogLive, :search, route_opts)
+                live("/search", BlogLive, :search, route_opts)
+              end
+
               if :show in routes do
                 pipe_through(:cloudflare_cdn)
                 live("/:slug", BlogLive, :show, route_opts)

--- a/test/literature/router_test.exs
+++ b/test/literature/router_test.exs
@@ -42,7 +42,9 @@ defmodule Literature.RouterTest do
                  "/blog/tags",
                  "/blog/page/:page",
                  "/blog/feed",
-                 "/literature"
+                 "/literature",
+                 "/blog/search",
+                 "/blog/search/page/:page"
                ])
 
       assert Routes.literature_path(conn, :index) == "/blog"
@@ -64,7 +66,13 @@ defmodule Literature.RouterTest do
       |> Enum.map(& &1.path)
 
     assert Enum.sort(paths) ==
-             Enum.sort(["/with-only", "/with-only/:slug", "/with-only/feed"])
+             Enum.sort([
+               "/with-only",
+               "/with-only/:slug",
+               "/with-only/feed",
+               "/with-only/search",
+               "/with-only/search/page/:page"
+             ])
 
     assert Routes.with_only_path(conn, :index) == "/with-only"
 
@@ -87,7 +95,9 @@ defmodule Literature.RouterTest do
                "/authors",
                "/tags",
                "/page/:page",
-               "/feed"
+               "/feed",
+               "/search",
+               "/search/page/:page"
              ])
 
     assert Routes.on_root_path(conn, :index) == "/"
@@ -117,7 +127,9 @@ defmodule Literature.RouterTest do
                "/custom-routes/tags/:tag_slug",
                "/custom-routes/tags/:tag_slug/page/:page",
                "/custom-routes/page/:page",
-               "/custom-routes/feed"
+               "/custom-routes/feed",
+               "/custom-routes/search",
+               "/custom-routes/search/page/:page"
              ])
 
     assert Routes.custom_routes_path(conn, :tags) == "/custom-routes/tags"
@@ -164,7 +176,9 @@ defmodule Literature.RouterTest do
                "/dynamic-on-root/authors",
                "/dynamic-on-root/tags",
                "/dynamic-on-root/page/:page",
-               "/dynamic-on-root/feed"
+               "/dynamic-on-root/feed",
+               "/dynamic-on-root/search",
+               "/dynamic-on-root/search/page/:page"
              ])
 
     assert DynamicPathRoutes.on_root_path(conn, :index) == "/dynamic-on-root"

--- a/test/literature_test.exs
+++ b/test/literature_test.exs
@@ -235,6 +235,37 @@ defmodule LiteratureTest do
       assert post.id == scheduled_post.id
     end
 
+    test "paginate_posts/1 returns filtered posts based on status & search term" do
+      publication = publication_fixture()
+      author = author_fixture(publication_id: publication.id)
+      tag = tag_fixture(publication_id: publication.id)
+
+      published_post_with_keyword =
+        post_fixture(
+          title: "Published post: Keyword phrase in the title",
+          publication_id: publication.id,
+          authors_ids: [author.id],
+          tags_ids: [tag.id]
+        )
+
+      draft_post_with_keyword =
+        post_fixture(
+          title: "Draft post: Keyword phrase in the title",
+          publication_id: publication.id,
+          authors_ids: [author.id],
+          tags_ids: [tag.id],
+          is_published: false
+        )
+
+      attrs = %{"q" => "keyword phrase", "status" => "published"}
+
+      result = Literature.paginate_posts(attrs)
+      post_ids = Enum.map(result, & &1.id)
+
+      assert published_post_with_keyword.id in post_ids
+      refute draft_post_with_keyword.id in post_ids
+    end
+
     test "list_posts/0 returns all posts" do
       publication = publication_fixture()
       author = author_fixture(publication_id: publication.id)

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -23,7 +23,7 @@ defmodule Literature.Test.Router do
 
   literature("/",
     publication: "with-only",
-    only: [:index, :show],
+    only: [:index, :show, :search],
     view_module: @view_module,
     as: :with_only
   )


### PR DESCRIPTION
The idea is to support a route like `/support/search?q=searchterm` and `/support/search/page/2?q=searchterm` where `support` is the publication and query param `q` is a search term.

This will return posts under a publication with a title, slug, excerpt, or content that matches the search term.